### PR TITLE
Replace the global symbol table implementation with `vector-hashables` `Dictionary Int WeakSymbol`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ and this project adheres to the
 
 ## Unreleased
 
+## 1.0.3.0
+
+- Swap internals of the global symbol table.
+  - Before: `IORef (Data.IntSet (NonEmpty WeakSymbol))`
+  - After: `MVar (HashTable.Dictionary (HashTable.PrimState IO) U.MVector Int V.MVector NonEmptyWeakSymbol)`
+    - Reading/writing to this mutable hashtable from the `vector-hashtables` package scales almost linearly
+    - The `NonEmpty WeakSymbol` is replaced by a monomorphised version of the same, reducing memory overhead by one more word per symbol.
+
 ## 1.0.2.4
 
 - Fix too eager creation of weak pointers, resulting in many needless allocations. This greatly reduces memory pressure and improves speed when inserting many symbols in a short amount of time! 

--- a/package.yaml
+++ b/package.yaml
@@ -51,11 +51,13 @@ dependencies:
 - deepseq              >= 1.4.0  && < 1.6
 - hashable             >= 1.4.0  && < 1.6
 - random               >= 1.2    && < 2
-- containers           >= 0.6.0  && < 0.8
+# - containers           >= 0.6.0  && < 0.8
+- hashtables           >=1.3     && < 2
 # Conversions to/from commonly-used string formats:
 - text-short           >= 0.1.0  && < 0.2
 - bytestring           >= 0.11.0 && < 0.13
 - text                 >= 2.0    && < 2.2
+# Serialisation:
 - binary               >= 0.8.9  && < 0.9
 
 ghc-options:

--- a/package.yaml
+++ b/package.yaml
@@ -52,7 +52,8 @@ dependencies:
 - hashable             >= 1.4.0  && < 1.6
 - random               >= 1.2    && < 2
 # - containers           >= 0.6.0  && < 0.8
-- hashtables           >=1.3     && < 2
+- vector-hashtables    >=0.1     && < 0.2
+- vector
 # Conversions to/from commonly-used string formats:
 - text-short           >= 0.1.0  && < 0.2
 - bytestring           >= 0.11.0 && < 0.13

--- a/package.yaml
+++ b/package.yaml
@@ -128,7 +128,6 @@ benchmarks:
     main: SymbolizeBench.hs
     build-depends:
       - symbolize
-      - vector
       - tasty-bench
     mixins:
       tasty-bench (Test.Tasty.Bench as Criterion, Test.Tasty.Bench as Criterion.Main, Test.Tasty.Bench as Gauge, Test.Tasty.Bench as Gauge.Main)

--- a/package.yaml
+++ b/package.yaml
@@ -76,6 +76,8 @@ library:
   other-modules:
   - Symbolize.Accursed
   - Symbolize.SipHash
+  - Symbolize.WeakSymbol
+  - Symbolize.NonEmptyWeakSymbol
   - Symbolize.SymbolTable
 
 tested-with:

--- a/package.yaml
+++ b/package.yaml
@@ -51,8 +51,7 @@ dependencies:
 - deepseq              >= 1.4.0  && < 1.6
 - hashable             >= 1.4.0  && < 1.6
 - random               >= 1.2    && < 2
-# - containers           >= 0.6.0  && < 0.8
-- vector-hashtables    >=0.1     && < 0.2
+- vector-hashtables    >= 0.1    && < 0.2
 - vector
 # Conversions to/from commonly-used string formats:
 - text-short           >= 0.1.0  && < 0.2

--- a/package.yaml
+++ b/package.yaml
@@ -52,7 +52,7 @@ dependencies:
 - hashable             >= 1.4.0  && < 1.6
 - random               >= 1.2    && < 2
 - vector-hashtables    >= 0.1    && < 0.2
-- vector
+- vector               >= 0.12.0 && < 0.14
 # Conversions to/from commonly-used string formats:
 - text-short           >= 0.1.0  && < 0.2
 - bytestring           >= 0.11.0 && < 0.13

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:                symbolize
-version:             1.0.2.4
+version:             1.0.3.0
 github:              "Qqwy/haskell-symbolize"
 license:             BSD-3-Clause
 author:              "Qqwy / Marten"

--- a/src/Symbolize/NonEmptyWeakSymbol.hs
+++ b/src/Symbolize/NonEmptyWeakSymbol.hs
@@ -1,0 +1,34 @@
+{-# LANGUAGE GHC2021 #-}
+module Symbolize.NonEmptyWeakSymbol 
+(NonEmptyWeakSymbol((:|)), 
+toList, 
+nonEmpty, 
+singleton, 
+cons
+) where
+
+import Symbolize.WeakSymbol (WeakSymbol)
+
+-- | A monomorphised version of `Data.List.NonEmpty`
+-- which allows its head `WeakSymbol` to be UNPACKed into it.
+-- Since we expect collisions to be _very_ rare,
+-- this skips the intermediate allocation almost always.
+data NonEmptyWeakSymbol where
+  (:|) :: {-# UNPACK #-} !WeakSymbol -> ![WeakSymbol] -> NonEmptyWeakSymbol
+
+toList :: NonEmptyWeakSymbol -> [WeakSymbol]
+{-# INLINE toList #-}
+toList (a :| as) = a : as
+
+nonEmpty :: [WeakSymbol] -> Maybe NonEmptyWeakSymbol
+{-# INLINE nonEmpty #-}
+nonEmpty [] = Nothing
+nonEmpty (a : as) = Just (a :| as)
+
+singleton :: WeakSymbol -> NonEmptyWeakSymbol
+{-# INLINE singleton #-}
+singleton a = a :| []
+
+cons :: WeakSymbol -> NonEmptyWeakSymbol -> NonEmptyWeakSymbol
+{-# INLINE cons #-}
+cons y (x :| xs) = y :| (x : xs)

--- a/src/Symbolize/SymbolTable.hs
+++ b/src/Symbolize/SymbolTable.hs
@@ -185,7 +185,7 @@ globalSymbolTable' :: GlobalSymbolTable
 -- SAFETY: We need all calls to globalSymbolTable' to use the same thunk, so NOINLINE.
 {-# NOINLINE globalSymbolTable' #-}
 globalSymbolTable' = unsafePerformIO $ do
-  !table <- HashTable.initialize 256
+  !table <- HashTable.initialize 128
   !ref <- MVar.newMVar (SymbolTable table)
   !sipkey <- Random.uniformM Random.globalStdGen
   pure (GlobalSymbolTable ref sipkey)

--- a/src/Symbolize/SymbolTable.hs
+++ b/src/Symbolize/SymbolTable.hs
@@ -27,7 +27,6 @@ import Data.List.NonEmpty qualified as NonEmpty
 import Data.Maybe (mapMaybe)
 import GHC.Exts (ByteArray#, StableName#, Weak#, deRefWeak#, makeStableName#, mkWeak#)
 import GHC.IO (IO (IO), unsafePerformIO)
-import Symbolize.Accursed qualified
 import Symbolize.Accursed qualified as Accursed
 import Symbolize.SipHash qualified as SipHash
 import System.IO.Unsafe qualified
@@ -61,8 +60,7 @@ newtype SymbolTable = SymbolTable (CuckooHashTable Int (NonEmpty WeakSymbol))
 --
 -- Current implementation details (these might change even between PVP-compatible versions):
 --
--- - An `IntMap` is used for mapping $(SipHash text) -> weak symbol$.
---   Such an IntMap has O(min(n, 64)) lookup time.
+-- - A `CuckooHashTable Int` is used for mapping $(SipHash text) -> weak symbol$.
 -- - Since SipHash is used as hashing algorithm and the key that is used
 --   is randomized on global table initialization,
 --   the table is resistent to HashDoS attacks.
@@ -90,49 +88,47 @@ insertGlobal ba# = do
   -- But finalization is idempotent, and only when a thread finally wins the Compare-and-Swap
   -- will its `weak` pointer be inserted (or alternatively another previously-inserted `ba` returned).
   -- So once this function returns, we can be sure we've returned a deduplicated ByteArray
-  MVar.modifyMVar gsymtab $ \table -> do
+  MVar.withMVar gsymtab $ \table -> do
     !weak <- mkWeakSymbol ba# (removeGlobal key)
-    case lookup ba# sipkey table of
-      Just ba -> pure (table, ba)
-      Nothing ->
-        pure (insert key weak table, ByteArray ba#)
+    res <- lookup ba# sipkey table
+    case res of
+      Just ba -> pure ba
+      Nothing -> do
+        insert key weak table
+        pure (ByteArray ba#)
 
 lookupGlobal :: ByteArray# -> IO (Maybe ByteArray)
 {-# INLINE lookupGlobal #-}
 lookupGlobal ba# = do
   GlobalSymbolTable gsymtab sipkey <- globalSymbolTable
-  MVar.withMVar gsymtab $ \table -> do
-    pure (lookup ba# sipkey table)
+  MVar.withMVar gsymtab (lookup ba# sipkey)
 
 removeGlobal :: Hash -> IO ()
 {-# INLINE removeGlobal #-}
 removeGlobal !key = do
   GlobalSymbolTable gsymtab _ <- globalSymbolTable
-  MVar.modifyMVar gsymtab $ \table -> do
-    pure (remove key table, ())
+  MVar.withMVar gsymtab (remove key)
 
-insert :: Hash -> WeakSymbol -> SymbolTable -> SymbolTable
+insert :: Hash -> WeakSymbol -> SymbolTable -> IO ()
 {-# INLINE insert #-}
-insert key weak (SymbolTable table) = unsafePerformIO $ do
+insert key weak (SymbolTable table) = do
   HashTable.mutate table (hashToInt key) $ \case
     Nothing -> (Just (pure weak), ())
     Just a -> (Just (NonEmpty.cons weak a), ())
-  pure (SymbolTable table)
 
-lookup :: ByteArray# -> Hash -> SymbolTable -> Maybe ByteArray
+lookup :: ByteArray# -> SipHash.SipKey -> SymbolTable -> IO (Maybe ByteArray)
 {-# INLINE lookup #-}
 lookup ba# sipkey (SymbolTable table) = do
   let !key = calculateHash sipkey ba#
-  weaks <- unsafePerformIO $ HashTable.lookup table (hashToInt key)
-  Foldable.find (\other -> other == ByteArray ba#) (aliveWeaks weaks)
+  weaks <- HashTable.lookup table (hashToInt key)
+  pure $ case weaks of
+    Nothing -> Nothing
+    Just weaks' ->
+      Foldable.find (\other -> other == ByteArray ba#) (aliveWeaks weaks')
 
-remove :: Hash -> SymbolTable -> SymbolTable
+remove :: Hash -> SymbolTable -> IO ()
 {-# INLINE remove #-}
-remove (Hash key) (SymbolTable table) =
-  let table' = unsafePerformIO $ do 
-        HashTable.mutate table key (\weaks -> (weaks >>= removeTombstones, ()))
-        pure table
-   in SymbolTable table'
+remove (Hash key) (SymbolTable table) = HashTable.mutate table key (\weaks -> (weaks >>= removeTombstones, ()))
   where
     removeTombstones = NonEmpty.nonEmpty . NonEmpty.filter isNoTombstone
     isNoTombstone weak =
@@ -165,7 +161,7 @@ deRefWeakSymbol :: WeakSymbol -> Maybe ByteArray
 deRefWeakSymbol (WeakSymbol# w _sn) = 
     -- SAFETY: This should even be safe
     -- in the presence of inlining, CSE and full laziness;
-    Symbolize.Accursed.accursedUnutterablePerformIO $ IO $ \s ->
+    Accursed.accursedUnutterablePerformIO $ IO $ \s ->
   case deRefWeak# w s of
     (# s1, flag, p #) -> case flag of
       0# -> (# s1, Nothing #)

--- a/src/Symbolize/SymbolTable.hs
+++ b/src/Symbolize/SymbolTable.hs
@@ -92,11 +92,11 @@ insertGlobal ba# = do
   -- will its `weak` pointer be inserted (or alternatively another previously-inserted `ba` returned).
   -- So once this function returns, we can be sure we've returned a deduplicated ByteArray
   MVar.withMVar gsymtab $ \table -> do
-    !weak <- mkWeakSymbol ba# (removeGlobal key)
     res <- lookup ba# sipkey table
     case res of
       Just ba -> pure ba
       Nothing -> do
+        !weak <- mkWeakSymbol ba# (removeGlobal key)
         insert key weak table
         pure (ByteArray ba#)
 

--- a/src/Symbolize/SymbolTable.hs
+++ b/src/Symbolize/SymbolTable.hs
@@ -69,12 +69,6 @@ insertGlobal :: ByteArray# -> IO ByteArray
 insertGlobal ba# = do
   GlobalSymbolTable gsymtab sipkey <- globalSymbolTable
   let !hash = calculateHash sipkey ba#
-  -- SAFETY: If the table IORef contested, 
-  -- this might trigger `weak` creation for the same bytestring from multiple threads
-  -- at the same time.
-  -- But finalization is idempotent, and only when a thread finally wins the Compare-and-Swap
-  -- will its `weak` pointer be inserted (or alternatively another previously-inserted `ba` returned).
-  -- So once this function returns, we can be sure we've returned a deduplicated ByteArray
   MVar.withMVar gsymtab $ \table -> do
     res <- lookup ba# sipkey table
     case res of

--- a/src/Symbolize/SymbolTable.hs
+++ b/src/Symbolize/SymbolTable.hs
@@ -21,8 +21,8 @@ import qualified Data.Vector.Mutable as VM
 import qualified Data.Vector.Unboxed.Mutable  as UM
 import Data.Vector.Hashtables qualified as HashTable
 import Data.List qualified
-import Data.List.NonEmpty (NonEmpty(..))
-import Data.List.NonEmpty qualified as NonEmpty
+-- import Data.List.NonEmpty (NonEmpty(..))
+-- import Data.List.NonEmpty qualified as NonEmpty
 import Data.Maybe (mapMaybe)
 import GHC.Exts (ByteArray#, StableName#, Weak#, deRefWeak#, makeStableName#, mkWeak#)
 import GHC.IO (IO (IO), unsafePerformIO)
@@ -48,7 +48,27 @@ import Control.Concurrent.MVar qualified as MVar
 data WeakSymbol where
   WeakSymbol# :: Weak# ByteArray# -> StableName# ByteArray# -> WeakSymbol
 
-newtype SymbolTable = SymbolTable (HashTable.Dictionary (HashTable.PrimState IO) UM.MVector Int VM.MVector (NonEmpty WeakSymbol))
+-- | A monomorphised version of `Data.List.NonEmpty`
+-- which allows its head `WeakSymbol` to be UNPACKed into it.
+-- Since we expect collisions to be _very_ rare,
+-- this skips the intermediate allocation almost always.
+data NonEmptyWeakSymbol where
+  (:|) :: {-# UNPACK #-} !WeakSymbol -> ![WeakSymbol] -> NonEmptyWeakSymbol
+
+nonEmptyToList :: NonEmptyWeakSymbol -> [WeakSymbol]
+nonEmptyToList (a :| as) = a : as
+
+nonEmptyFromList :: [WeakSymbol] -> Maybe NonEmptyWeakSymbol
+nonEmptyFromList [] = Nothing
+nonEmptyFromList (a : as) = Just (a :| as)
+
+singletonNonEmptyWeakSymbol :: WeakSymbol -> NonEmptyWeakSymbol
+singletonNonEmptyWeakSymbol a = a :| []
+
+consNonEmptyWeakSymbol :: WeakSymbol -> NonEmptyWeakSymbol -> NonEmptyWeakSymbol
+consNonEmptyWeakSymbol y (x :| xs) = y :| (x : xs)
+
+newtype SymbolTable = SymbolTable (HashTable.Dictionary (HashTable.PrimState IO) UM.MVector Int VM.MVector NonEmptyWeakSymbol)
 
 -- | The global Symbol Table, containing a mapping between each symbol's textual representation and its deduplicated pointer.
 --
@@ -111,10 +131,10 @@ removeGlobal !key = do
 insert :: Hash -> WeakSymbol -> SymbolTable -> IO ()
 {-# INLINE insert #-}
 insert key weak (SymbolTable table) = HashTable.alter table insertOrConcat (hashToInt key)
-  where 
+  where
     insertOrConcat = \case
-      Nothing -> Just (pure weak)
-      Just a -> Just (NonEmpty.cons weak a)
+      Nothing -> Just (singletonNonEmptyWeakSymbol weak)
+      Just weaks -> Just (consNonEmptyWeakSymbol weak weaks)
 
 lookup :: ByteArray# -> SipHash.SipKey -> SymbolTable -> IO (Maybe ByteArray)
 {-# INLINE lookup #-}
@@ -128,9 +148,9 @@ lookup ba# sipkey (SymbolTable table) = do
 
 remove :: Hash -> SymbolTable -> IO ()
 {-# INLINE remove #-}
-remove (Hash key) (SymbolTable table) = HashTable.alter table (\weaks -> (weaks >>= removeTombstones)) key
+remove (Hash key) (SymbolTable table) = HashTable.alter table (>>= removeTombstones) key
   where
-    removeTombstones = NonEmpty.nonEmpty . NonEmpty.filter isNoTombstone
+    removeTombstones = nonEmptyFromList . filter isNoTombstone . nonEmptyToList
     isNoTombstone weak =
       case deRefWeakSymbol weak of
         Nothing -> False
@@ -144,7 +164,7 @@ calculateHash sipkey ba# =
 
 mkWeakSymbol :: ByteArray# -> IO () -> IO WeakSymbol
 {-# INLINE mkWeakSymbol #-}
-mkWeakSymbol ba# (IO finalizer#) = 
+mkWeakSymbol ba# (IO finalizer#) =
     -- SAFETY: This should even be safe
     -- in the presence of inlining, CSE and full laziness
     --
@@ -158,7 +178,7 @@ mkWeakSymbol ba# (IO finalizer#) =
 
 deRefWeakSymbol :: WeakSymbol -> Maybe ByteArray
 {-# INLINE deRefWeakSymbol #-}
-deRefWeakSymbol (WeakSymbol# w _sn) = 
+deRefWeakSymbol (WeakSymbol# w _sn) =
     -- SAFETY: This should even be safe
     -- in the presence of inlining, CSE and full laziness;
     Accursed.accursedUnutterablePerformIO $ IO $ \s ->
@@ -167,9 +187,9 @@ deRefWeakSymbol (WeakSymbol# w _sn) =
       0# -> (# s1, Nothing #)
       _ -> (# s1, Just (ByteArray p) #)
 
-aliveWeaks :: NonEmpty WeakSymbol -> [ByteArray]
+aliveWeaks :: NonEmptyWeakSymbol -> [ByteArray]
 {-# INLINE aliveWeaks #-}
-aliveWeaks = mapMaybe deRefWeakSymbol . NonEmpty.toList
+aliveWeaks = mapMaybe deRefWeakSymbol . nonEmptyToList
 
 -- | Get a handle to the `GlobalSymbolTable`
 --

--- a/src/Symbolize/SymbolTable.hs
+++ b/src/Symbolize/SymbolTable.hs
@@ -21,11 +21,9 @@ import qualified Data.Vector.Mutable as VM
 import qualified Data.Vector.Unboxed.Mutable  as UM
 import Data.Vector.Hashtables qualified as HashTable
 import Data.List qualified
--- import Data.List.NonEmpty (NonEmpty(..))
--- import Data.List.NonEmpty qualified as NonEmpty
 import Data.Maybe (mapMaybe)
-import GHC.Exts (ByteArray#, StableName#, Weak#, deRefWeak#, makeStableName#, mkWeak#)
-import GHC.IO (IO (IO), unsafePerformIO)
+import GHC.Exts (ByteArray#)
+import GHC.IO (unsafePerformIO)
 import Symbolize.Accursed qualified as Accursed
 import Symbolize.SipHash qualified as SipHash
 import System.IO.Unsafe qualified
@@ -33,40 +31,10 @@ import System.Random.Stateful qualified as Random (Uniform (uniformM), globalStd
 import Prelude hiding (lookup)
 import Control.Concurrent (MVar)
 import Control.Concurrent.MVar qualified as MVar
-
--- Inside the WeakSymbol
--- we keep:
--- - A weak pointer to the underlying ByteArray#.
---   This weak pointer will be invalidated (turn into a 'tombstone')
---   when the final instance of this symbol is GC'd
--- - A `StableName` for the same ByteArray#
---   This ensures we have a stable hash even in the presence of the ByteArray#
---   being moved around by the GC.
---   We never read it after construction,
---   but by keeping it around until the WeakSymbol is removed by the finalizer,
---   we ensure that future calls to `makeStableName` return the same hash.
-data WeakSymbol where
-  WeakSymbol# :: Weak# ByteArray# -> StableName# ByteArray# -> WeakSymbol
-
--- | A monomorphised version of `Data.List.NonEmpty`
--- which allows its head `WeakSymbol` to be UNPACKed into it.
--- Since we expect collisions to be _very_ rare,
--- this skips the intermediate allocation almost always.
-data NonEmptyWeakSymbol where
-  (:|) :: {-# UNPACK #-} !WeakSymbol -> ![WeakSymbol] -> NonEmptyWeakSymbol
-
-nonEmptyToList :: NonEmptyWeakSymbol -> [WeakSymbol]
-nonEmptyToList (a :| as) = a : as
-
-nonEmptyFromList :: [WeakSymbol] -> Maybe NonEmptyWeakSymbol
-nonEmptyFromList [] = Nothing
-nonEmptyFromList (a : as) = Just (a :| as)
-
-singletonNonEmptyWeakSymbol :: WeakSymbol -> NonEmptyWeakSymbol
-singletonNonEmptyWeakSymbol a = a :| []
-
-consNonEmptyWeakSymbol :: WeakSymbol -> NonEmptyWeakSymbol -> NonEmptyWeakSymbol
-consNonEmptyWeakSymbol y (x :| xs) = y :| (x : xs)
+import Symbolize.WeakSymbol (WeakSymbol)
+import Symbolize.WeakSymbol qualified as WeakSymbol
+import Symbolize.NonEmptyWeakSymbol (NonEmptyWeakSymbol)
+import Symbolize.NonEmptyWeakSymbol qualified as NonEmptyWeakSymbol
 
 newtype SymbolTable = SymbolTable (HashTable.Dictionary (HashTable.PrimState IO) UM.MVector Int VM.MVector NonEmptyWeakSymbol)
 
@@ -112,8 +80,8 @@ insertGlobal ba# = do
     case res of
       Just ba -> pure ba
       Nothing -> do
-        !weak <- mkWeakSymbol ba# (removeGlobal key)
-        insert key weak table
+        !weak <- WeakSymbol.new ba# (removeGlobal hash)
+        insert hash weak table
         pure (ByteArray ba#)
 
 lookupGlobal :: ByteArray# -> IO (Maybe ByteArray)
@@ -133,8 +101,8 @@ insert :: Hash -> WeakSymbol -> SymbolTable -> IO ()
 insert key weak (SymbolTable table) = HashTable.alter table insertOrConcat (hashToInt key)
   where
     insertOrConcat = \case
-      Nothing -> Just (singletonNonEmptyWeakSymbol weak)
-      Just weaks -> Just (consNonEmptyWeakSymbol weak weaks)
+      Nothing -> Just (NonEmptyWeakSymbol.singleton weak)
+      Just weaks -> Just (NonEmptyWeakSymbol.cons weak weaks)
 
 lookup :: ByteArray# -> SipHash.SipKey -> SymbolTable -> IO (Maybe ByteArray)
 {-# INLINE lookup #-}
@@ -150,9 +118,9 @@ remove :: Hash -> SymbolTable -> IO ()
 {-# INLINE remove #-}
 remove (Hash key) (SymbolTable table) = HashTable.alter table (>>= removeTombstones) key
   where
-    removeTombstones = nonEmptyFromList . filter isNoTombstone . nonEmptyToList
+    removeTombstones = NonEmptyWeakSymbol.nonEmpty . filter isNoTombstone . NonEmptyWeakSymbol.toList
     isNoTombstone weak =
-      case deRefWeakSymbol weak of
+      case WeakSymbol.deref weak of
         Nothing -> False
         Just _ -> True
 
@@ -162,34 +130,9 @@ calculateHash sipkey ba# =
   let (SipHash.SipHash word) = SipHash.hash sipkey (ByteArray ba#)
    in Hash (fromIntegral word)
 
-mkWeakSymbol :: ByteArray# -> IO () -> IO WeakSymbol
-{-# INLINE mkWeakSymbol #-}
-mkWeakSymbol ba# (IO finalizer#) =
-    -- SAFETY: This should even be safe
-    -- in the presence of inlining, CSE and full laziness
-    --
-    -- because the result is outwardly pure
-    -- and the finalizer we use is idempotent
-  IO $ \s1 -> case mkWeak# ba# ba# finalizer# s1 of
-    (# s2, weak# #) ->
-      case makeStableName# ba# s2 of
-        (# s3, sname# #) ->
-          (# s3, WeakSymbol# weak# sname# #)
-
-deRefWeakSymbol :: WeakSymbol -> Maybe ByteArray
-{-# INLINE deRefWeakSymbol #-}
-deRefWeakSymbol (WeakSymbol# w _sn) =
-    -- SAFETY: This should even be safe
-    -- in the presence of inlining, CSE and full laziness;
-    Accursed.accursedUnutterablePerformIO $ IO $ \s ->
-  case deRefWeak# w s of
-    (# s1, flag, p #) -> case flag of
-      0# -> (# s1, Nothing #)
-      _ -> (# s1, Just (ByteArray p) #)
-
 aliveWeaks :: NonEmptyWeakSymbol -> [ByteArray]
 {-# INLINE aliveWeaks #-}
-aliveWeaks = mapMaybe deRefWeakSymbol . nonEmptyToList
+aliveWeaks = mapMaybe WeakSymbol.deref . NonEmptyWeakSymbol.toList
 
 -- | Get a handle to the `GlobalSymbolTable`
 --

--- a/src/Symbolize/SymbolTable.hs
+++ b/src/Symbolize/SymbolTable.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# OPTIONS_HADDOCK hide, prune #-}
+{-# LANGUAGE LambdaCase #-}
 
 module Symbolize.SymbolTable
   ( insertGlobal,
@@ -18,8 +19,10 @@ import Data.Array.Byte (ByteArray (ByteArray))
 import Data.Foldable qualified as Foldable
 import Data.IORef (IORef)
 import Data.IORef qualified as IORef
-import Data.IntMap.Strict (IntMap)
-import Data.IntMap.Strict qualified as IntMap
+-- import Data.IntMap.Strict (IntMap)
+-- import Data.IntMap.Strict qualified as IntMap
+import Data.HashTable.IO (CuckooHashTable)
+import Data.HashTable.IO qualified as HashTable
 import Data.List qualified
 import Data.List.NonEmpty (NonEmpty(..))
 import Data.List.NonEmpty qualified as NonEmpty
@@ -47,7 +50,7 @@ import Prelude hiding (lookup)
 data WeakSymbol where
   WeakSymbol# :: Weak# ByteArray# -> StableName# ByteArray# -> WeakSymbol
 
-newtype SymbolTable = SymbolTable (IntMap (NonEmpty WeakSymbol))
+newtype SymbolTable = SymbolTable (CuckooHashTable Int (NonEmpty WeakSymbol))
 
 -- | The global Symbol Table, containing a mapping between each symbol's textual representation and its deduplicated pointer.
 --
@@ -72,7 +75,8 @@ instance Show GlobalSymbolTable where
   -- SAFETY: We're only reading, and do not care about performance here.
   show (GlobalSymbolTable table _) = System.IO.Unsafe.unsafePerformIO $ do
     SymbolTable symtab <- IORef.readIORef table
-    let contents = Data.List.sort $ map Accursed.shortTextFromBA $ foldMap aliveWeaks $ IntMap.elems symtab
+    elems <- fmap snd <$> HashTable.toList symtab
+    let contents = Data.List.sort $ map Accursed.shortTextFromBA $ foldMap aliveWeaks elems
     pure $ "GlobalSymbolTable { size = " <> show (length contents) <> ", symbols = " <> show contents <> " }"
 
 insertGlobal :: ByteArray# -> IO ByteArray
@@ -110,20 +114,25 @@ removeGlobal !key = do
 
 insert :: Hash -> WeakSymbol -> SymbolTable -> SymbolTable
 {-# INLINE insert #-}
-insert key weak (SymbolTable table) =
-  let table' = IntMap.alter (Just . maybe (pure weak) (NonEmpty.cons weak)) (hashToInt key) table
-   in SymbolTable table'
+insert key weak (SymbolTable table) = unsafePerformIO $ do
+  HashTable.mutate table (hashToInt key) $ \case
+    Nothing -> (Just (pure weak), ())
+    Just a -> (Just (NonEmpty.cons weak a), ())
+  pure (SymbolTable table)
 
 lookup :: ByteArray# -> Hash -> SymbolTable -> Maybe ByteArray
 {-# INLINE lookup #-}
-lookup ba# hash (SymbolTable table) = do
-  weaks <- IntMap.lookup (hashToInt hash) table
+lookup ba# sipkey (SymbolTable table) = do
+  let !key = calculateHash sipkey ba#
+  weaks <- unsafePerformIO $ HashTable.lookup table (hashToInt key)
   Foldable.find (\other -> other == ByteArray ba#) (aliveWeaks weaks)
 
 remove :: Hash -> SymbolTable -> SymbolTable
 {-# INLINE remove #-}
 remove (Hash key) (SymbolTable table) =
-  let table' = IntMap.update removeTombstones key table
+  let table' = unsafePerformIO $ do 
+        HashTable.mutate table key (\weaks -> (weaks >>= removeTombstones, ()))
+        pure table
    in SymbolTable table'
   where
     removeTombstones = NonEmpty.nonEmpty . NonEmpty.filter isNoTombstone
@@ -177,14 +186,18 @@ globalSymbolTable' :: GlobalSymbolTable
 -- SAFETY: We need all calls to globalSymbolTable' to use the same thunk, so NOINLINE.
 {-# NOINLINE globalSymbolTable' #-}
 globalSymbolTable' = unsafePerformIO $ do
-  !ref <- IORef.newIORef (SymbolTable mempty)
+  !table <- HashTable.new
+  !ref <- IORef.newIORef (SymbolTable table)
   !sipkey <- Random.uniformM Random.globalStdGen
   pure (GlobalSymbolTable ref sipkey)
 
 -- | Returns the current size of the global symbol table. Useful for introspection or metrics.
+--
+-- Should not be used in high-performance code, as it might walk over the full table.
 globalSymbolTableSize :: IO Word
 globalSymbolTableSize = do
   GlobalSymbolTable gsymtab _ <- globalSymbolTable
   SymbolTable table <- IORef.readIORef gsymtab
-  let size = fromIntegral (IntMap.size table)
+  elems <- HashTable.toList table
+  let size = fromIntegral (length elems)
   pure size

--- a/src/Symbolize/SymbolTable.hs
+++ b/src/Symbolize/SymbolTable.hs
@@ -17,13 +17,9 @@ where
 import Control.Monad.IO.Class (MonadIO (liftIO))
 import Data.Array.Byte (ByteArray (ByteArray))
 import Data.Foldable qualified as Foldable
--- import Data.IORef (IORef)
--- import Data.IORef qualified as IORef
 import qualified Data.Vector.Mutable as VM
 import qualified Data.Vector.Unboxed.Mutable  as UM
 import Data.Vector.Hashtables qualified as HashTable
--- import Data.HashTable.IO (CuckooHashTable)
--- import Data.HashTable.IO qualified as HashTable
 import Data.List qualified
 import Data.List.NonEmpty (NonEmpty(..))
 import Data.List.NonEmpty qualified as NonEmpty

--- a/src/Symbolize/WeakSymbol.hs
+++ b/src/Symbolize/WeakSymbol.hs
@@ -1,0 +1,57 @@
+{-# LANGUAGE GHC2021 #-}
+{-# LANGUAGE UnboxedTuples #-}
+{-# LANGUAGE MagicHash #-}
+module Symbolize.WeakSymbol (WeakSymbol, new, deref) where
+
+import Data.Array.Byte (ByteArray (ByteArray))
+import GHC.Exts (ByteArray#, StableName#, Weak#, deRefWeak#, mkWeak#, makeStableName#)
+import GHC.IO (IO (IO))
+import Symbolize.Accursed qualified as Accursed
+
+-- Inside the WeakSymbol
+-- we keep:
+-- - A weak pointer to the underlying ByteArray#.
+--   This weak pointer will be invalidated (turn into a 'tombstone')
+--   when the final instance of this symbol is GC'd
+-- - A `StableName` for the same ByteArray#
+--   This ensures we have a stable hash even in the presence of the ByteArray#
+--   being moved around by the GC.
+--   We never read it after construction,
+--   but by keeping it around until the WeakSymbol is removed by the finalizer,
+--   we ensure that future calls to `makeStableName` return the same hash.
+data WeakSymbol where
+  WeakSymbol# :: Weak# ByteArray# -> StableName# ByteArray# -> WeakSymbol
+
+-- | Create a new weak symbol
+-- based on the given symbol content ByteArray
+-- and finalizer to run when the weak symbol
+-- is no longer needed.
+new :: ByteArray# -> IO () -> IO WeakSymbol
+{-# INLINE new #-}
+new ba# (IO finalizer#) =
+    -- SAFETY: This should even be safe
+    -- in the presence of inlining, CSE and full laziness
+    --
+    -- because the result is outwardly pure
+    -- and the finalizer we use is idempotent
+  IO $ \s1 -> case mkWeak# ba# ba# finalizer# s1 of
+    (# s2, weak# #) ->
+      case makeStableName# ba# s2 of
+        (# s3, sname# #) ->
+          (# s3, WeakSymbol# weak# sname# #)
+
+-- | Attempt to get back the containing ByteArray#
+-- by looking inside this `WeakSymbol`
+--
+-- Returns `Nothing` if it was GC'd in the meantime
+-- (which may be before, after or concurrently with when the finalizer runs)
+deref :: WeakSymbol -> Maybe ByteArray
+{-# INLINE deref #-}
+deref (WeakSymbol# w _sn) =
+    -- SAFETY: This should even be safe
+    -- in the presence of inlining, CSE and full laziness;
+    Accursed.accursedUnutterablePerformIO $ IO $ \s ->
+  case deRefWeak# w s of
+    (# s1, flag, p #) -> case flag of
+      0# -> (# s1, Nothing #)
+      _ -> (# s1, Just (ByteArray p) #)

--- a/symbolize.cabal
+++ b/symbolize.cabal
@@ -58,6 +58,8 @@ library
   other-modules:
       Symbolize.Accursed
       Symbolize.SipHash
+      Symbolize.WeakSymbol
+      Symbolize.NonEmptyWeakSymbol
       Symbolize.SymbolTable
   hs-source-dirs:
       src

--- a/symbolize.cabal
+++ b/symbolize.cabal
@@ -72,9 +72,9 @@ library
       base >=4.7 && <5
     , binary >=0.8.9 && <0.9
     , bytestring >=0.11.0 && <0.13
-    , containers >=0.6.0 && <0.8
     , deepseq >=1.4.0 && <1.6
     , hashable >=1.4.0 && <1.6
+    , hashtables >=1.3 && <2
     , random >=1.2 && <2
     , text >=2.0 && <2.2
     , text-short >=0.1.0 && <0.2
@@ -100,10 +100,10 @@ test-suite symbolize-doctest
       base >=4.7 && <5
     , binary >=0.8.9 && <0.9
     , bytestring >=0.11.0 && <0.13
-    , containers >=0.6.0 && <0.8
     , deepseq >=1.4.0 && <1.6
     , doctest-parallel
     , hashable >=1.4.0 && <1.6
+    , hashtables >=1.3 && <2
     , random >=1.2 && <2
     , symbolize
     , text >=2.0 && <2.2
@@ -134,9 +134,9 @@ test-suite symbolize-test
     , base >=4.7 && <5
     , binary >=0.8.9 && <0.9
     , bytestring >=0.11.0 && <0.13
-    , containers >=0.6.0 && <0.8
     , deepseq >=1.4.0 && <1.6
     , hashable >=1.4.0 && <1.6
+    , hashtables >=1.3 && <2
     , hedgehog
     , random >=1.2 && <2
     , symbolize

--- a/symbolize.cabal
+++ b/symbolize.cabal
@@ -74,10 +74,11 @@ library
     , bytestring >=0.11.0 && <0.13
     , deepseq >=1.4.0 && <1.6
     , hashable >=1.4.0 && <1.6
-    , hashtables >=1.3 && <2
     , random >=1.2 && <2
     , text >=2.0 && <2.2
     , text-short >=0.1.0 && <0.2
+    , vector
+    , vector-hashtables ==0.1.*
   default-language: Haskell2010
 
 test-suite symbolize-doctest
@@ -103,11 +104,12 @@ test-suite symbolize-doctest
     , deepseq >=1.4.0 && <1.6
     , doctest-parallel
     , hashable >=1.4.0 && <1.6
-    , hashtables >=1.3 && <2
     , random >=1.2 && <2
     , symbolize
     , text >=2.0 && <2.2
     , text-short >=0.1.0 && <0.2
+    , vector
+    , vector-hashtables ==0.1.*
   default-language: Haskell2010
 
 test-suite symbolize-test
@@ -136,7 +138,6 @@ test-suite symbolize-test
     , bytestring >=0.11.0 && <0.13
     , deepseq >=1.4.0 && <1.6
     , hashable >=1.4.0 && <1.6
-    , hashtables >=1.3 && <2
     , hedgehog
     , random >=1.2 && <2
     , symbolize
@@ -146,6 +147,8 @@ test-suite symbolize-test
     , tasty-hunit
     , text >=2.0 && <2.2
     , text-short >=0.1.0 && <0.2
+    , vector
+    , vector-hashtables ==0.1.*
   default-language: Haskell2010
 
 benchmark symbolize-bench

--- a/symbolize.cabal
+++ b/symbolize.cabal
@@ -171,7 +171,6 @@ benchmark symbolize-bench
       base >=4.7 && <5
     , binary >=0.8.9 && <0.9
     , bytestring >=0.11.0 && <0.13
-    , containers >=0.6.0 && <0.8
     , deepseq >=1.4.0 && <1.6
     , hashable >=1.4.0 && <1.6
     , random >=1.2 && <2
@@ -180,4 +179,5 @@ benchmark symbolize-bench
     , text >=2.0 && <2.2
     , text-short >=0.1.0 && <0.2
     , vector
+    , vector-hashtables ==0.1.*
   default-language: Haskell2010


### PR DESCRIPTION
Currently, the global symbol table is backed by a `Data.IntMap WeakSymbol`. That is a persistent dictionary type. However, we do not make use of this persistence really, instead mutating it in place all the time.

Instead, the `vector-hashtables` package has a type called `Dictionary` which has much better data locality as it is backed by `Vector`s.

Switching this does require us to stop using `atomicModifyIORef'` as it uses optimistic compare-and-swap rather than pessimistic locking, which would mean that it won't actually prevent concurrent changes to the hashtable (which itself uses another `IORef` or other `MutVar` for its internals). Instead, we need to place it behind an `MVar` and use `withMVar` to ensure only one thread alters it at one time.
That is not entirely free, though it
- is offset by the faster hashtable;
- as nice side-benefit it makes the code a lot nicer on the eyes (we can get rid of a lot of nested `(accursedUnutterable)UnsafePerformIO`s).

Fixes #7 
(See benchmarking results also in that issue)


---

While we're at it, I also decided to monomorphize the `NonEmpty WeakSymbol` into a type aptly called `NonEmptyWeakSymbol` that behaves exactly the same, except that the head weak symbol gets unpacked into it, which is very useful since it will be super rare for these lists to have more than one element (since that would imply a hash collision). That reduces the used amount of memory by a word per symbol.